### PR TITLE
add err() for counters without proper formatting

### DIFF
--- a/Base Actions/ccspellimport.alias
+++ b/Base Actions/ccspellimport.alias
@@ -11,6 +11,8 @@ aConvert = {
 }
 
 def automate(ability, ccname):
+        if ':' not in ccname:
+	        err(f"Your counter {ccname} doesn't have the proper format to import. `<ability>: <spell>` is the format.  Like `Shadow Touched (Wisdom):  False Life`")
 	spell = ccname[ccname.index(":")+2:]
 
 	automation = {


### PR DESCRIPTION
`ValueError: substring not found` is not as straightforward as telling players they formatted their counter incorrectly and spoon-feeding them the correct format.  Hope this helps.